### PR TITLE
Enable PHP 7.3 and 7.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: php
 
 php:
   - 7.2
-  # - 7.3
-  # - nightly
+  - 7.3
+  - 7.4snapshot
 
 cache:
   directories:


### PR DESCRIPTION
Fixes #1 

`nightly` now refers to PHP 8.0 on Travis. They use `7.4snapshot` for pre-release PHP 7.4.

When PHP 7.4 releases, just need to remove `snapshot`